### PR TITLE
Allow Filament 5.x in composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
   ],
   "require": {
     "php": "^8.2",
-    "filafly/filament-icons": "^2.0",
+    "filafly/filament-icons": "^2.1",
     "afatmustafa/blade-hugeicons": "^1.0",
-    "filament/filament": "^4.0"
+    "filament/filament": "^4.0 || ^5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I noticed that the base package of this repository,
[https://github.com/filafly/filament-icons](https://github.com/filafly/filament-icons)
has recently been updated to support Filament v5.

Therefore, I decided to open this PR. The only changes made are two updates in the `composer.json` file, mirroring the adjustments in the base package to add support for the latest Filament version.

This will close issue #3 